### PR TITLE
Make importable with webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/index');
+module.exports = 'nemLogging';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-simple-logger",
   "version": "0.1.7",
   "description": "Basic logger with level logging which can also be independent.",
-  "main": "./dist/index.js",
+  "main": "index.js",
   "scripts": {
     "start": "gulp",
     "test": "gulp spec"


### PR DESCRIPTION
With Webpack 2 and Angular 1.x with this
```javascript
import angularSimpleLogger from 'angular-simple-logger'

angular.module('app', [angularSimpleLogger])
```
Is throwing this angular error when it spins up
```
app.bundle.js:55447 Uncaught Error: [$injector:modulerr] Failed to instantiate module app due to:
Error: [$injector:modulerr] Failed to instantiate module {} due to:
Error: [ng:areq] Argument 'module' is not a function, got Object
http://errors.angularjs.org/1.5.9/ng/areq?p0=module&p1=not%20a%20function%2C%20got%20Object
```

I'm not sure why, but the change in this PR fixes that. Not sure if it introduces other problems.